### PR TITLE
reference Amazon Linux 2018

### DIFF
--- a/doc_source/compare-options-choose-lightsail-instance-image.md
+++ b/doc_source/compare-options-choose-lightsail-instance-image.md
@@ -1,6 +1,6 @@
 # Choose an Amazon Lightsail instance image<a name="compare-options-choose-lightsail-instance-image"></a>
 
- *Last updated: July 26, 2019* 
+ *Last updated: November 24, 2019* 
 
 Lightsail provides several options for you to create your virtual private server\. This topic helps you decide which operating system \(OS\), application, or development stack is right for your project\. We organized the applications by functional area \(e\.g\., CMS and e\-Commerce\)\.
 
@@ -24,7 +24,7 @@ Windows Server 2012 R2 is also available as a base operating system\. If you're 
 You can use Windows Server 2012 R2 with the same use cases as listed under Windows Server 2016\.  
  [Learn more about the Windows Server 2012 R2 image](https://aws.amazon.com/marketplace/pp/B00KQOWCAQ) 
 
-** **Amazon Linux 2017** **  
+** **Amazon Linux 2018** **  
 The Amazon Linux AMI is a supported and maintained Linux image provided by Amazon Web Services \(AWS\) for use on Lightsail and Amazon EC2\. It's designed to provide a stable, secure, and high\-performance execution environment for applications running on Lightsail\. It includes packages that enable easy integration with AWS, such as the AWS Command Line Interface \(AWS CLI\) and AWS API tools\. AWS provides ongoing security and maintenance updates to all instances running the Amazon Linux AMI\.  
 [Learn more about the Amazon Linux AMI](https://aws.amazon.com/amazon-linux-ami/)
 

--- a/doc_source/what-is-amazon-lightsail.md
+++ b/doc_source/what-is-amazon-lightsail.md
@@ -1,6 +1,6 @@
 # What is Amazon Lightsail?<a name="what-is-amazon-lightsail"></a>
 
- *Last updated: July 26, 2019* 
+ *Last updated: November 24, 2019* 
 
 Amazon Lightsail is the easiest way to get started with AWS if you just need virtual private servers\. Lightsail includes everything you need to launch your project quickly – a virtual machine, SSD\-based storage, data transfer, DNS management, and a static IP – for a low, predictable price\. After you create your instance, you can easily connect to it\. You can manage your instances using the Lightsail console, Lightsail API, or Lightsail command line interface \(CLI\)\.
 
@@ -19,7 +19,7 @@ You can also create a Lightsail load balancer and attach target instances to cre
 ## Operating systems in Lightsail<a name="what-operating-systems-templates-are-available-in-lightsail"></a>
 
 **Linux**
-+ Amazon Linux 2017
++ Amazon Linux 2018
 + CentOS 7
 + Ubuntu Server 16 and 18
 + Free BSD 10


### PR DESCRIPTION
*Issue*

Amazon Linux 2017 no longer supporter.

*Description of changes:*

Referencing Amazon Linux 2018