### PR TITLE
Ambiguity around using a CNAME on Route53

### DIFF
--- a/doc_source/add-alias-record-for-lightsail-load-balancer.md
+++ b/doc_source/add-alias-record-for-lightsail-load-balancer.md
@@ -33,9 +33,7 @@ After you [verify that you control the domain where you want to have encrypted \
 
 1. Choose **Create Record Set**\.
 
-1. For **Name**, type `www`\.
-**Note**  
-If you're using an apex domain, you need to point your apex to a subdomain \(like `www`\) and then use a CNAME there to point to the load balancer\.
+1. For **Name**, type `www` in front of `example.com` or don't use a prefix if using an apex domain\.
 
 1. Accept the default record \(**A \- IPv4 address**\)\.
 


### PR DESCRIPTION
Using a CNAME for an ALIAS on Route53 is not supported. I have aligned the wording to be similar to the Lightsail example and removed the note about CNAMEs.

In this case we are manually specifying the Alias Target and thus its possible to create a CNAME record with and ALIAS that won't resolve.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
