### PR TITLE
Update create-and-attach-additional-block-storage-disks-linux-unix.md

### DIFF
--- a/doc_source/create-and-attach-additional-block-storage-disks-linux-unix.md
+++ b/doc_source/create-and-attach-additional-block-storage-disks-linux-unix.md
@@ -172,7 +172,7 @@ You probably want to mount this disk every time you reboot your Lightsail instan
    For example, your new line might look something like this\.
 
    ```
-   /dev/xvdf /data ext4 defaults, nofail 0 2
+   /dev/xvdf /data ext4 defaults,nofail 0 2
    ```
 
 1. Save the file and exit your text editor\.


### PR DESCRIPTION
There isn't any space in between "defaults" and "nofail".

Doing it causes the instance to not to restart in case of typos in the path of mounted devices or the actual path in the first parameter.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
