### PR TITLE
Update mount command

### DIFF
--- a/doc_source/amazon-lightsail-create-an-instance-root-volume-snapshot.md
+++ b/doc_source/amazon-lightsail-create-an-instance-root-volume-snapshot.md
@@ -134,7 +134,7 @@ To access a block storage disk after attaching it to an instance, you must mount
    **Example:**
 
    ```
-   sudo mount /dev/xvdf1 xvdf
+   sudo mount /dev/xvdf1  xvdf
    ```
 
 1. Enter the following command to view the block storage disk devices attached to the instance:


### PR DESCRIPTION
sudo mount /dev/xvdf1xvdf to sudo mount /dev/xvdf1  xvdf in AWS doc page - https://lightsail.aws.amazon.com/ls/docs/en_us/articles/amazon-lightsail-create-an-instance-root-volume-snapshot there is no space.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
