### PR TITLE
Update amazon-lightsail-editing-wp-config-for-distribution.md

### DIFF
--- a/doc_source/amazon-lightsail-editing-wp-config-for-distribution.md
+++ b/doc_source/amazon-lightsail-editing-wp-config-for-distribution.md
@@ -42,11 +42,11 @@ We recommend that you create a snapshot of your WordPress instance before gettin
    define('WP_HOME', 'http://' . $_SERVER['HTTP_HOST'] . '/');
    ```
 
-1. Add the following lines of code to the file, where you previously deleted the code\.
+1. Add the following lines of code to the file, where you previously deleted the code\.  Add www to DOMAIN if you would like it so.
 
    ```
-   define('WP_SITEURL', 'https://' . $_SERVER['HTTP_HOST'] . '/');
-   define('WP_HOME', 'https://' . $_SERVER['HTTP_HOST'] . '/');
+   define('WP_SITEURL', 'https://DOMAIN/');
+   define('WP_HOME', 'https://DOMAIN/');
    if (isset($_SERVER['HTTP_CLOUDFRONT_FORWARDED_PROTO'])
    && $_SERVER['HTTP_CLOUDFRONT_FORWARDED_PROTO'] === 'https') {
    $_SERVER['HTTPS'] = 'on';


### PR DESCRIPTION
Since WordPress v3.3.1-5 or higher, bitnami recommends that the domain name is written straight in the wp-config.php file. This is also how to enforce non-www to www redirection or the other way around.

ref: https://docs.bitnami.com/aws/apps/wordpress/administration/configure-domain/

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
