### PR TITLE
UPDATE amazon-lightsail-install-software.md

### DIFF
--- a/doc_source/amazon-lightsail-install-software.md
+++ b/doc_source/amazon-lightsail-install-software.md
@@ -102,7 +102,7 @@ For more information about Homebrew, see the [Homebrew](https://brew.sh/) websit
 1. Enter the following command to download the lightsailctl plugin and copy it to the bin folder\.
 
    ```
-   curl "https://s3.us-west-2.amazonaws.com/lightsailctl/latest/darwin-amd64/lightsailctl" -o "/usr/local/bin/lightsailctl"
+   curl "https://s3.us-west-2.amazonaws.com/lightsailctl/latest/darwin-$(uname -m)/lightsailctl" -o "/usr/local/bin/lightsailctl"
    ```
 
 1. Enter the following command to make the plugin executable\.


### PR DESCRIPTION
*Issue #, if available:*
manual install not working out of the box via apple silicon as curl command is amd64 only. 

*Description of changes:*
make the manual install of lightsailctl cpu architecture agnostig (for apple sillicon)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
